### PR TITLE
Add cross-platform Unix build script and makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ modules/dynamic_modules/fulltick/fulltick.vcxproj.filters
 modules/dynamic_modules/fulltick/fulltick.vcxproj.user
 
 ''$'\001\213\212''@@'
+
+dist/

--- a/build/Unix-Build.sh
+++ b/build/Unix-Build.sh
@@ -13,6 +13,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)"
 # Getting the absolute paths of the relative paths to the script directory
 simple_executable_makefile_path=$(cd "$script_dir/../simple/makefiles" 2> /dev/null && pwd -P)
 dynamic_modules_makefile_path=$(cd "$script_dir/../modules/dynamic_modules/makefiles" 2> /dev/null && pwd -P)
+dynamic_library_ext="so"
 
 
 # ENTRY FUNCTIONS
@@ -20,6 +21,8 @@ main() {
     clear
 
 	check_if_is_sudo $@
+
+	get_os_platform
 
 	for param in "$@"
 	do
@@ -88,7 +91,7 @@ build_executable() {
 dynamic_modules_init() {
 	# The __first_calls.sim is important for the simple-lang modules to function
 	if [ -f $2 ]; then
-		echo "callDynamicModule(\"systemic.so\") callDynamicModule(\"string_savant.so\")" >> $2
+		echo "callDynamicModule(\"systemic.$dynamic_library_ext\") callDynamicModule(\"string_savant.$dynamic_library_ext\")" >> $2
         header "setup" "Dynamic modules setup completed"
 	else
 		display_error $1 "cannot find the __first_calls.sim file "
@@ -154,6 +157,7 @@ get_os_platform() {
 		  ;;
 		*darwin* )
 		  local myos="macosx"
+		  dynamic_library_ext="dylib"
 		  ;;
 		*aix* )
 		  local myos="aix"
@@ -191,7 +195,7 @@ help() {
 	echo "	-h --help	display this help message"
 	echo ""
 	echo "[STANDALONE BUILD FLAGS] :"
-	echo "	-so --simple-only	build only simple and libsimple.so"
+	echo "	-so --simple-only	build only simple and libsimple.$dynamic_library_ext"
 	echo "	-io --includes-only	copy only the simple includes files"
 	echo "	-mo --modules-only	copy only the standard modules"
 	echo "	-yo --dymodules-only	build only the dynamic modules"

--- a/build/Unix-Build.sh
+++ b/build/Unix-Build.sh
@@ -1,0 +1,222 @@
+# LANGUAGE INFORMATION
+version="0.3.36"
+program_name="simple"
+
+# PATHS
+makefile="Makefile-Unix.mk"
+current_dir=`pwd`
+first_call_file="/var/lib/$program_name/s$version/modules/simple/core/__first_calls.sim"
+
+# The following allows the script to be run from anywhere
+# Getting the absolute path of where script is running from
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)"
+# Getting the absolute paths of the relative paths to the script directory
+simple_executable_makefile_path=$(cd "$script_dir/../simple/makefiles" 2> /dev/null && pwd -P)
+dynamic_modules_makefile_path=$(cd "$script_dir/../modules/dynamic_modules/makefiles" 2> /dev/null && pwd -P)
+
+
+# ENTRY FUNCTIONS
+main() {
+    clear
+
+	check_if_is_sudo $@
+
+	for param in "$@"
+	do
+		if [ "$param" = "-h" ] || [ "$param" = "--help" ]; then
+			flag="help"
+		elif [ "$param" = "-u" ] || [ "$param" = "--uninstall" ]; then
+			flag="uninstall"
+		elif [ "$param" = "-i" ] || [ "$param" = "--install" ]; then
+            flag="install"
+		fi
+	done
+
+    run_program $flag
+
+    exit 0
+}
+
+run_program() {
+    case $1 in
+		*help* )
+			help
+		;;
+		*uninstall* )
+			uninstall
+		;;
+		*install* )
+			install
+		;;
+	esac
+}
+
+# BUILD FUNCTIONS
+install() {
+    build_executable
+    build_dynamic_modules
+}
+
+build_dynamic_modules() {
+    if [ -d $dynamic_modules_makefile_path ]; then
+        header "install" "Installing dynamic modules..."
+        cd $dynamic_modules_makefile_path
+        make -s -f $makefile install
+        make -s -f $makefile clean
+        cd $current_dir
+		dynamic_modules_init "setup" $first_call_file
+        header "success" "Dynamic modules installed"
+    else
+        not_found_error "build" $dynamic_modules_makefile_path
+    fi
+}
+
+build_executable() {
+    if [ -d $simple_executable_makefile_path ]; then
+        header "install" "Installing simple executables and libraries..."
+        cd $simple_executable_makefile_path
+        make -s -f $makefile install
+        make -s -f $makefile clean
+        cd $current_dir
+        header "success" "Executables and libraries installed"
+    else
+        not_found_error "build" $simple_executable_makefile_path
+    fi
+}
+
+# SETUP FUNCTIONS
+dynamic_modules_init() {
+	# The __first_calls.sim is important for the simple-lang modules to function
+	if [ -f $2 ]; then
+		echo "callDynamicModule(\"systemic.so\") callDynamicModule(\"string_savant.so\")" >> $2
+        header "setup" "Dynamic modules setup completed"
+	else
+		display_error $1 "cannot find the __first_calls.sim file "
+	fi
+}
+
+# CLEAN-UP FUNCTIONS
+uninstall() {
+    if [ -d $dynamic_modules_makefile_path ]; then
+        header "uninstall" "Removing installed dynamic modules..."
+        cd $dynamic_modules_makefile_path
+        make -s -f $makefile uninstall
+        cd $current_dir
+    else
+        not_found_error "build" $dynamic_modules_makefile_path
+    fi
+    if [ -d $simple_executable_makefile_path ]; then
+        header "uninstall" "Removing installed libraries and executables"
+        cd $simple_executable_makefile_path
+        make -s -f $makefile uninstall
+        cd $current_dir
+        header "success" "Simple dependencies removed"
+    else
+        not_found_error "build" $simple_executable_makefile_path
+    fi
+}
+
+# COPY FUNCTIONS
+
+# ENVIRONMENT INFORMATION FUNCTIONS
+check_if_is_sudo() {
+	if [ "$(id -u)" -ne 0 ]; then
+		display sudo "it appear you are not running the script as root"
+		display sudo "the script is reinitiated as root"
+		display sudo "if it fails to re execute the Unix-Build.sh script with sudo"
+		display sudo "manualy run the script with 'sudo sh Unix-Build.sh -c -i'"
+		exit 0
+	fi
+}
+
+get_os_platform() {
+	  # Get OS/CPU info and store in a `myos` and `mycpu` variable.
+	  local ucpu=`uname -m`
+	  local uos=`uname`
+	  local ucpu=`echo $ucpu | tr "[:upper:]" "[:lower:]"`
+	  local uos=`echo $uos | tr "[:upper:]" "[:lower:]"`
+
+	  case $uos in
+		*linux* )
+		  local myos="linux"
+		  ;;
+		*dragonfly* )
+		  local myos="freebsd"
+		  ;;
+		*freebsd* )
+		  local myos="freebsd"
+		  ;;
+		*openbsd* )
+		  local myos="openbsd"
+		  ;;
+		*netbsd* )
+		  local myos="netbsd"
+		  ;;
+		*darwin* )
+		  local myos="macosx"
+		  ;;
+		*aix* )
+		  local myos="aix"
+		  ;;
+		*solaris* | *sun* )
+		  local myos="solaris"
+		  ;;
+		*haiku* )
+		  local myos="haiku"
+		  ;;
+		*mingw* )
+		  local myos="windows"
+		  ;;
+		*)
+		  display_error "unknown operating system: $uos"
+		  ;;
+	  esac
+
+	echo "$myos"
+}
+
+# PRINT FUNCTIONS
+help() {
+	header "help" "$version"
+	echo "Usage: sudo sh Linux-Build.sh [FLAG]"
+	echo "[FLAGS] :"
+	echo "	-c --configure	configure your system for simple-lang successful build"
+	echo "	-i --install	install simple-lang on your system"
+	echo "	-u --uninstall	remove simple-lang installation from your system"
+	echo "	-d --debug	create a distributable(archivable) version in ../../ source directory"
+	echo "	-x --deb	create a .deb package that can be install with 'dpkg -i simple*.deb'"
+	echo "	x86 --32-bit	build 32 bit version of simple-lang"
+	echo "	x64 --64-bit	build 64 bit version of simple-lang"
+	echo "	-t --temp	keep the */dist/ folder(s) in source tree"
+	echo "	-h --help	display this help message"
+	echo ""
+	echo "[STANDALONE BUILD FLAGS] :"
+	echo "	-so --simple-only	build only simple and libsimple.so"
+	echo "	-io --includes-only	copy only the simple includes files"
+	echo "	-mo --modules-only	copy only the standard modules"
+	echo "	-yo --dymodules-only	build only the dynamic modules"
+	echo "	-eo --environment-only	build only the environment programs"
+}
+
+header() {
+	echo "=================================================================="
+	echo "simple-lang:$1: $2"
+	echo "=================================================================="
+}
+
+not_found_error() {
+	display_error $1 "simple-lang $version build"
+	display_error $1 "the file '$2' does not exist in simple directory"
+	display_error $1 "skipping the build... on to next command..."
+}
+
+display_error() {
+	display "$1:error" $2
+}
+
+display() {
+	echo "simple-lang:$1: $2"
+}
+
+main $@
+

--- a/modules/dynamic_modules/archiver/Makefile-Unix.mk
+++ b/modules/dynamic_modules/archiver/Makefile-Unix.mk
@@ -1,0 +1,48 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := archiver
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c)
+OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILES = $(CC) $(RELOCATION_FLAG) $(DISABLE_WARNING_FLAG) $< -c -o $@
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILES) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(shell $(CREATE_BUILD_DIR))
+
+$(BUILD_DIR)/%.o:$(SOURCE_DIR)/%.c
+	$(COMPILE_OBJECT_FILES)
+
+$(LIB_FILE): $(OBJECT_FILES)
+	$(BUILD_SIMPLE_MAIN)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/archiver/Makefile-Unix.mk
+++ b/modules/dynamic_modules/archiver/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c)
 OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/consoler/Makefile-Unix.mk
+++ b/modules/dynamic_modules/consoler/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/consoler/Makefile-Unix.mk
+++ b/modules/dynamic_modules/consoler/Makefile-Unix.mk
@@ -1,0 +1,45 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := consoler
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/consoler/consoler.c
+++ b/modules/dynamic_modules/consoler/consoler.c
@@ -1,11 +1,11 @@
 
-/* 
-    Copyright (c) 2018 Azeez Adewale <azeezadewale98@gmail.com> 
-    MIT License Copyright (c) 2018 simple 
+/*
+    Copyright (c) 2018 Azeez Adewale <azeezadewale98@gmail.com>
+    MIT License Copyright (c) 2018 simple
 
 */
 
-/* 
+/*
  * File:   consoler.h
  * Author: thecarisma
  *
@@ -15,11 +15,15 @@
 #include "../../../simple/includes/simple.h"
 #include "consoler.h"
 
+#if defined(__GNUC__)
+#include <stdarg.h>
+#endif
+
 #ifdef _WIN32
 	#define SIMPLE_API __declspec(dllexport)
 #else
 #if defined(_MSC_VER)
-    //  Microsoft 
+    //  Microsoft
     #define SIMPLE_API __declspec(dllexport)
     #define SIMPLE_API __declspec(dllimport)
 #elif defined(__GNUC__)
@@ -35,12 +39,10 @@
 #endif
 
 SIMPLE_API void init_simple_module(SimpleState *sState)
-{   
+{
     register_block("__flush_console",program_flush_console);
     register_block("__printwfb",print_with_foreground_background);
     register_block("__exit",program_exit);
-    register_block("__sleep",program_sleep);
-    
 }
 
 void program_flush_console(void *pointer)
@@ -81,17 +83,6 @@ void program_exit ( void *pointer )
 		}
 	}
 	exit(0);
-}
-
-void program_sleep ( void *pointer )
-{
-    if ( SIMPLE_API_PARACOUNT == 1 ) {
-        if ( SIMPLE_API_ISNUMBER(1) ) {
-            _sleep(SIMPLE_API_GETNUMBER(1));
-            return ;
-        }
-    }
-    _sleep(0);
 }
 
 static int Write(FILE *stream, const char *format, va_list ap) {

--- a/modules/dynamic_modules/core_dynamic_module/Makefile-Unix.mk
+++ b/modules/dynamic_modules/core_dynamic_module/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/core_dynamic_module/Makefile-Unix.mk
+++ b/modules/dynamic_modules/core_dynamic_module/Makefile-Unix.mk
@@ -1,0 +1,45 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := core_dynamic_module
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/file_savant/Makefile-Unix.mk
+++ b/modules/dynamic_modules/file_savant/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/file_savant/Makefile-Unix.mk
+++ b/modules/dynamic_modules/file_savant/Makefile-Unix.mk
@@ -1,0 +1,45 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := file_savant
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/fulltick/Makefile-Unix.mk
+++ b/modules/dynamic_modules/fulltick/Makefile-Unix.mk
@@ -1,0 +1,47 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := fulltick
+BUILD_DIR := $(DIST)/build
+USR_LOCAL_INCLUDE := /usr/local/include
+SOURCE_DIR := .
+SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c $(SOURCE_DIR)/includes/*.cpp)
+OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.cpp=%.o)))
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -lpthread -ldl -lm -lfltk # -lfontconfig -lX11 -lXfixes -lXinerama -lXft
+OTHER_FLAGS := -fpermissive -fvisibility-inlines-hidden -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_THREAD_SAFE -D_REENTRANT
+INCLUDE_FLAGS := -I$(USR_LOCAL_INCLUDE) -I$(USR_LOCAL_INCLUDE)/FL/images
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_LIBRARY := $(CXX) $(RELOCATION_FLAG) $(DISABLE_WARNING_FLAG) $(INCLUDE_FLAGS) $(LINK_FLAGS) $(LIB_FLAGS) $(SOURCE_FILES) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(LIB_FILE): $(SOURCE_FILES)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/fulltick/Makefile-Unix.mk
+++ b/modules/dynamic_modules/fulltick/Makefile-Unix.mk
@@ -7,13 +7,19 @@ USR_LOCAL_INCLUDE := /usr/local/include
 SOURCE_DIR := .
 SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c $(SOURCE_DIR)/includes/*.cpp)
 OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.cpp=%.o)))
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -lpthread -ldl -lm -lfltk # -lfontconfig -lX11 -lXfixes -lXinerama -lXft
 OTHER_FLAGS := -fpermissive -fvisibility-inlines-hidden -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_THREAD_SAFE -D_REENTRANT
 INCLUDE_FLAGS := -I$(USR_LOCAL_INCLUDE) -I$(USR_LOCAL_INCLUDE)/FL/images
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/makefiles/Makefile-Unix.mk
+++ b/modules/dynamic_modules/makefiles/Makefile-Unix.mk
@@ -21,18 +21,27 @@ MODULE_DIR := ../..
 DYNAMIC_MODULES_DIR := ..
 DYNAMIC_MODULES_EXCLUDE := $(addprefix $(DYNAMIC_MODULES_DIR)/,dist makefiles)
 DYNAMIC_MODULES_FOLDERS := $(filter-out $(DYNAMIC_MODULES_EXCLUDE), $(wildcard $(DYNAMIC_MODULES_DIR)/*))
+OSNAME := $(shell uname)
+
+ifeq ($(OSNAME), Darwin)
+LIB_FILES := $(addprefix $(DIST)/,$(notdir $(DYNAMIC_MODULES_FOLDERS:%=%.dylib)))
+else
 LIB_FILES := $(addprefix $(DIST)/,$(notdir $(DYNAMIC_MODULES_FOLDERS:%=%.so)))
+endif
 
 # Folder creation commands
 CREATE_BUILD_DIR := mkdir -p $(DIST)/build
 CREATE_VAR_MODULE_DIR := mkdir -p $(VAR_DYNAMIC_MODULES_DIR) $(VAR_MODULE_DIR)/docs
 
 # Compile commands
-RECURSIVE_MAKE = $(MAKE) -f Makefile-Unix.mk -C $(DYNAMIC_MODULES_DIR)/$*
+RECURSIVE_MAKE =  $(MAKE) -f Makefile-Unix.mk -C $(DYNAMIC_MODULES_DIR)/$*
 
 # .SILENT:
 
 $(DIST)/%.so: $(DYNAMIC_MODULES_DIR)/%
+	$(RECURSIVE_MAKE)
+
+$(DIST)/%.dylib: $(DYNAMIC_MODULES_DIR)/%
 	$(RECURSIVE_MAKE)
 
 build: $(LIB_FILES)

--- a/modules/dynamic_modules/makefiles/Makefile-Unix.mk
+++ b/modules/dynamic_modules/makefiles/Makefile-Unix.mk
@@ -1,0 +1,57 @@
+# This makefiile generates the following dynamic libraries:
+# - archiver
+# - consoler
+# - file_savant
+# - mathic
+# - string_savant
+# - networker
+# - parser
+# - security
+# - systemic
+# - core_dynamic_module
+# - fulltick
+
+PROGRAM_NAME := simple
+VER := 0.3.36
+VAR_VER_DIR := /var/lib/$(PROGRAM_NAME)/s$(VER)
+VAR_MODULE_DIR := $(VAR_VER_DIR)/modules
+VAR_DYNAMIC_MODULES_DIR := $(VAR_MODULE_DIR)/dynamic_modules
+DIST := ../dist
+MODULE_DIR := ../..
+DYNAMIC_MODULES_DIR := ..
+DYNAMIC_MODULES_EXCLUDE := $(addprefix $(DYNAMIC_MODULES_DIR)/,dist makefiles)
+DYNAMIC_MODULES_FOLDERS := $(filter-out $(DYNAMIC_MODULES_EXCLUDE), $(wildcard $(DYNAMIC_MODULES_DIR)/*))
+LIB_FILES := $(addprefix $(DIST)/,$(notdir $(DYNAMIC_MODULES_FOLDERS:%=%.so)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(DIST)/build
+CREATE_VAR_MODULE_DIR := mkdir -p $(VAR_DYNAMIC_MODULES_DIR) $(VAR_MODULE_DIR)/docs
+
+# Compile commands
+RECURSIVE_MAKE = $(MAKE) -f Makefile-Unix.mk -C $(DYNAMIC_MODULES_DIR)/$*
+
+# .SILENT:
+
+$(DIST)/%.so: $(DYNAMIC_MODULES_DIR)/%
+	$(RECURSIVE_MAKE)
+
+build: $(LIB_FILES)
+
+install: $(LIB_FILES)
+	$(CREATE_VAR_MODULE_DIR)
+	rsync -q -av $(MODULE_DIR) $(VAR_MODULE_DIR) --exclude README.md --exclude dynamic_modules
+	rsync -q -av $(LIB_FILES) $(VAR_DYNAMIC_MODULES_DIR)
+	chmod -R 777 /var/lib/$(PROGRAM_NAME)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+# NOTE:
+#   We don't remove the main simple directory from /var/lib because it
+#   it may contain dependencies and modules for another simple version
+uninstall:
+	rm -rf -f $(VAR_VER_DIR)
+
+all: uninstall clean install clean
+.PHONY: build all uninstall install clean

--- a/modules/dynamic_modules/mathic/Makefile-Unix.mk
+++ b/modules/dynamic_modules/mathic/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/mathic/Makefile-Unix.mk
+++ b/modules/dynamic_modules/mathic/Makefile-Unix.mk
@@ -1,0 +1,45 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := mathic
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/networker/Makefile-Unix.mk
+++ b/modules/dynamic_modules/networker/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Add -lCurl flag if on macos
 ifneq ($(OS),Windows_NT)

--- a/modules/dynamic_modules/networker/Makefile-Unix.mk
+++ b/modules/dynamic_modules/networker/Makefile-Unix.mk
@@ -1,0 +1,53 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := networker
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Add -lCurl flag if on macos
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		CURL_FLAG := -lcurl
+	endif
+endif
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) $(CURL_FLAG) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/parser/Makefile-Unix.mk
+++ b/modules/dynamic_modules/parser/Makefile-Unix.mk
@@ -1,0 +1,51 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := parser
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c $(SOURCE_DIR)/includes/*.c)
+OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILES = gcc $(RELOCATION_FLAG) $(DISABLE_WARNING_FLAG) $< -c -o $@
+COMPILE_LIBRARY :=  gcc $(LINK_FLAGS) $(OBJECT_FILES) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(shell $(CREATE_BUILD_DIR))
+
+$(BUILD_DIR)/%.o:$(SOURCE_DIR)/includes/%.c
+	$(COMPILE_OBJECT_FILES)
+
+$(BUILD_DIR)/%.o:$(SOURCE_DIR)/%.c
+	$(COMPILE_OBJECT_FILES)
+
+$(LIB_FILE): $(OBJECT_FILES)
+	$(BUILD_SIMPLE_MAIN)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/parser/Makefile-Unix.mk
+++ b/modules/dynamic_modules/parser/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c $(SOURCE_DIR)/includes/*.c)
 OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/parser/includes/printbuf.c
+++ b/modules/dynamic_modules/parser/includes/printbuf.c
@@ -72,7 +72,7 @@ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 #endif /* !HAVE_VSNPRINTF && defined(WIN32) */
 /* error removed manually on linux */
 
-#if !HAVE_VASPRINTF
+#if !HAVE_VASPRINTF && defined(_WIN32)
 /* CAW: compliant version of vasprintf */
 static int vasprintf(char **buf, const char *fmt, va_list ap)
 {

--- a/modules/dynamic_modules/security/Makefile-Unix.mk
+++ b/modules/dynamic_modules/security/Makefile-Unix.mk
@@ -1,0 +1,45 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := security
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LIB_FLAGS := -lssl -lcrypto -L../../../simple/dist/ -l$(PROGRAM_NAME)
+LINK_FLAGS := -shared
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/security/Makefile-Unix.mk
+++ b/modules/dynamic_modules/security/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LIB_FLAGS := -lssl -lcrypto -L../../../simple/dist/ -l$(PROGRAM_NAME)
 LINK_FLAGS := -shared
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/security/openssl/rand.h
+++ b/modules/dynamic_modules/security/openssl/rand.h
@@ -113,7 +113,7 @@ int RAND_egd(const char *path);
 int RAND_egd_bytes(const char *path, int bytes);
 int RAND_poll(void);
 
-# if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
+# if (defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)) && defined(_WIN32)
 
 void RAND_screen(void);
 int RAND_event(UINT, WPARAM, LPARAM);

--- a/modules/dynamic_modules/string_savant/Makefile-Unix.mk
+++ b/modules/dynamic_modules/string_savant/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/string_savant/Makefile-Unix.mk
+++ b/modules/dynamic_modules/string_savant/Makefile-Unix.mk
@@ -1,0 +1,45 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := string_savant
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(CREATE_BUILD_DIR)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/systemic/Makefile-Unix.mk
+++ b/modules/dynamic_modules/systemic/Makefile-Unix.mk
@@ -1,0 +1,44 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+FILE := systemic
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := .
+SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
+OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
+LIB_FILE := $(DIST)/$(FILE).so
+DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
+LINK_FLAGS := -shared
+LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
+RELOCATION_FLAG := -fPIC
+
+# Dependency information
+SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources
+SIMPLE_MAIN_BUILD_DIR := ../../../simple/dist/build
+SIMPLE_MAIN_MAKEFILES_DIR := ../../../simple/makefiles
+SIMPLE_MAIN_SOURCE_FILES := $(wildcard $(SIMPLE_MAIN_SOURCE_DIR)/*.c)
+SIMPLE_MAIN_OBJECT_FILES := $(addprefix $(SIMPLE_MAIN_BUILD_DIR)/,$(notdir $(SIMPLE_MAIN_SOURCE_FILES:%.c=%.o)))
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(BUILD_DIR)
+
+# Compile commands
+COMPILE_OBJECT_FILE = $(CC) $(RELOCATION_FLAG) $(SOURCE_FILE) $(DISABLE_WARNING_FLAG) -c -o $(OBJECT_FILE)
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILE) $(LIB_FLAGS) -o $(LIB_FILE)
+BUILD_SIMPLE_MAIN := $(MAKE) -f Makefile-Unix.mk -C $(SIMPLE_MAIN_MAKEFILES_DIR)
+
+# .SILENT:
+
+$(OBJECT_FILE): $(SOURCE_FILE)
+	$(BUILD_SIMPLE_MAIN)
+	$(COMPILE_OBJECT_FILE)
+	$(COMPILE_LIBRARY)
+
+build: $(LIB_FILE)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+all: build
+.PHONY: build all uninstall run

--- a/modules/dynamic_modules/systemic/Makefile-Unix.mk
+++ b/modules/dynamic_modules/systemic/Makefile-Unix.mk
@@ -6,11 +6,17 @@ BUILD_DIR := $(DIST)/build
 SOURCE_DIR := .
 SOURCE_FILE := $(SOURCE_DIR)/$(FILE).c
 OBJECT_FILE := $(BUILD_DIR)/$(FILE).o
-LIB_FILE := $(DIST)/$(FILE).so
 DISABLE_WARNING_FLAG := -w # -Wno-implicit-function-declaration -Wno-int-conversion
 LINK_FLAGS := -shared
 LIB_FLAGS := -L../../../simple/dist/ -l$(PROGRAM_NAME)
 RELOCATION_FLAG := -fPIC
+
+OSNAME := $(shell uname)
+ifeq ($(OSNAME), Darwin)
+LIB_FILE := $(DIST)/$(FILE).dylib
+else
+LIB_FILE := $(DIST)/$(FILE).so
+endif
 
 # Dependency information
 SIMPLE_MAIN_SOURCE_DIR := ../../../simple/sources

--- a/modules/dynamic_modules/systemic/systemic.c
+++ b/modules/dynamic_modules/systemic/systemic.c
@@ -1,11 +1,11 @@
 
-/* 
-    Copyright (c) 2016-2018 Azeez Adewale <azeezadewale98@gmail.com> 
-    MIT License Copyright (c) 2018 simple 
+/*
+    Copyright (c) 2016-2018 Azeez Adewale <azeezadewale98@gmail.com>
+    MIT License Copyright (c) 2018 simple
 
 */
 
-/* 
+/*
  * File:   systemic.c
  * Author: thecarisma
  *
@@ -17,6 +17,9 @@
 typedef int (WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL); ;
 LPFN_ISWOW64PROCESS isWindows64  ;
 #endif
+#if defined(__APPLE__) && defined(__MACH__)
+#define _beep(x,y) printf("\a")
+#endif
 
 #include "../../../simple/includes/simple.h"
 #include "systemic.h"
@@ -25,7 +28,7 @@ LPFN_ISWOW64PROCESS isWindows64  ;
 	#define SIMPLE_API __declspec(dllexport)
 #else
 #if defined(_MSC_VER)
-    //  Microsoft 
+    //  Microsoft
     #define SIMPLE_API __declspec(dllexport)
 #elif defined(__GNUC__)
     //  GCC
@@ -36,9 +39,9 @@ LPFN_ISWOW64PROCESS isWindows64  ;
     #pragma warning Unknown dynamic link import/export semantics.
 #endif
 #endif
-        
+
 SIMPLE_API void init_simple_module(SimpleState *sState)
-{   
+{
     register_block("isMsDos",os_ismsdos);
     register_block("isWindows",os_iswindows);
     register_block("isWindows64",os_iswindows64);
@@ -90,7 +93,7 @@ void os_iswindows64 ( void *pointer )
 	if ( isWindows64 != NULL ) {
 		isWindows64(GetCurrentProcess(),&lSystem64);
 		SIMPLE_API_RETNUMBER(1);
-		return; 
+		return;
 	}
 	#endif
 	SIMPLE_API_RETNUMBER(lSystem64);
@@ -215,8 +218,8 @@ void current_filepath ( void *pointer )
 	}
 	if ( (vm->nBlockExecute2 > 0) && (simple_list_getsize(vm->pBlockCallList)>0) ) {
 		/*
-		**  Here we have Load Function Instruction - But Still the function is not called 
-		**  FunctionName (  ***Parameters**** We are here! ) 
+		**  Here we have Load Function Instruction - But Still the function is not called
+		**  FunctionName (  ***Parameters**** We are here! )
 		*/
 		nPos = simple_list_getsize(vm->pBlockCallList)  -  (vm->nBlockExecute2 - 1) ;
 		if ( (nPos > 0) && (nPos <= simple_list_getsize(vm->pBlockCallList)) ) {
@@ -227,7 +230,7 @@ void current_filepath ( void *pointer )
 		}
 		return ;
 	}
-        
+
 	SIMPLE_API_RETSTRING(vm->file_name);
 }
 
@@ -243,8 +246,8 @@ void current_filename ( void *pointer )
     }
     if ( (vm->nBlockExecute2 > 0) && (simple_list_getsize(vm->pBlockCallList)>0) ) {
         /*
-        **  Here we have Load Function Instruction - But Still the function is not called 
-        **  FunctionName (  ***Parameters**** We are here! ) 
+        **  Here we have Load Function Instruction - But Still the function is not called
+        **  FunctionName (  ***Parameters**** We are here! )
         */
         nPos = simple_list_getsize(vm->pBlockCallList)  -  (vm->nBlockExecute2 - 1) ;
         if ( (nPos > 0) && (nPos <= simple_list_getsize(vm->pBlockCallList)) ) {

--- a/simple/makefiles/Makefile-Unix.mk
+++ b/simple/makefiles/Makefile-Unix.mk
@@ -6,7 +6,7 @@ SOURCE_DIR := ../sources
 SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c)
 OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
 HEADER_FILES := ../includes/.
-SIMPLE_LIB := lib$(PROGRAM_NAME).so
+SIMPLE_LIB := lib$(PROGRAM_NAME).dylib
 ENTRY_FILE := ../simple.c
 LIB_FLAGS := -lm -ldl
 USR_LOCAL := /usr/local
@@ -39,6 +39,7 @@ $(DIST)/$(PROGRAM_NAME): $(OBJECT_FILES)
 build: $(OBJECT_FILES) $(DIST)/$(PROGRAM_NAME)
 
 install: $(OBJECT_FILES) $(DIST)/$(PROGRAM_NAME)
+	echo $(USR_LOCAL)
 	# Add executable to /usr/local/bin
 	cp $(DIST)/$(PROGRAM_NAME) $(USR_LOCAL)/bin/$(PROGRAM_NAME)
 	# Add library to /usr/local/lib

--- a/simple/makefiles/Makefile-Unix.mk
+++ b/simple/makefiles/Makefile-Unix.mk
@@ -1,0 +1,66 @@
+PROGRAM_NAME := simple
+VER := 0.3.36
+DIST := ../dist
+BUILD_DIR := $(DIST)/build
+SOURCE_DIR := ../sources
+SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c)
+OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
+HEADER_FILES := ../includes/.
+SIMPLE_LIB := lib$(PROGRAM_NAME).so
+ENTRY_FILE := ../simple.c
+LIB_FLAGS := -lm -ldl
+USR_LOCAL := /usr/local
+DISABLE_WARNING_FLAG := -Wno-parentheses-equality
+RUNTIME_LIB_PATH_FLAGS := -Wl,-rpath,$(USR_LOCAL)/lib -Wl,-rpath,./
+COMPILE_TIME_LIB_PATH_FLAG := -L$(DIST)
+PATH_FLAGS := $(COMPILE_TIME_LIB_PATH_FLAG) $(RUNTIME_LIB_PATH_FLAGS)
+LINK_FLAGS := -shared
+RELOCATION_FLAG := -fPIC
+
+# Folder creation commands
+CREATE_BUILD_DIR := mkdir -p $(DIST)/build
+
+# Compile commands
+COMPILE_OBJECT_FILES = $(CC) $(DISABLE_WARNING_FLAG) $(RELOCATION_FLAG) $< -c -o $@
+COMPILE_LIBRARY := $(CC) $(LINK_FLAGS) $(OBJECT_FILES) $(LIB_FLAGS) -o $(DIST)/$(SIMPLE_LIB)
+COMPILE_EXECUTABLE := $(CC) $(PATH_FLAGS) $(ENTRY_FILE) -l$(PROGRAM_NAME) -o $(DIST)/$(PROGRAM_NAME)
+
+# .SILENT:
+
+$(shell $(CREATE_BUILD_DIR))
+
+$(BUILD_DIR)/%.o:$(SOURCE_DIR)/%.c
+	$(COMPILE_OBJECT_FILES)
+
+$(DIST)/$(PROGRAM_NAME): $(OBJECT_FILES)
+	$(COMPILE_LIBRARY)
+	$(COMPILE_EXECUTABLE)
+
+build: $(OBJECT_FILES) $(DIST)/$(PROGRAM_NAME)
+
+install: $(OBJECT_FILES) $(DIST)/$(PROGRAM_NAME)
+	# Add executable to /usr/local/bin
+	cp $(DIST)/$(PROGRAM_NAME) $(USR_LOCAL)/bin/$(PROGRAM_NAME)
+	# Add library to /usr/local/lib
+	cp $(DIST)/$(SIMPLE_LIB) $(USR_LOCAL)/lib/$(SIMPLE_LIB)
+	# Add header files to /usr/local/include/simple
+	cp -a $(HEADER_FILES) $(USR_LOCAL)/include/$(PROGRAM_NAME)
+
+clean:
+	rm -rf $(DIST)
+	$(CREATE_BUILD_DIR)
+
+uninstall:
+	# Remove executable from /usr/local/bin
+	rm -f $(USR_LOCAL)/bin/$(PROGRAM_NAME)
+	# Remove library from /usr/local/lib
+	rm -f $(USR_LOCAL)/lib/$(SIMPLE_LIB)
+	# Remove header files from /usr/local/include/simple
+	rm -rf $(USR_LOCAL)/include/$(PROGRAM_NAME)
+
+run:
+	$(PROGRAM_NAME)
+
+
+all: uninstall clean install clean run
+.PHONY: build all uninstall install clean run

--- a/simple/makefiles/Makefile-Unix.mk
+++ b/simple/makefiles/Makefile-Unix.mk
@@ -1,12 +1,17 @@
 PROGRAM_NAME := simple
 VER := 0.3.36
 DIST := ../dist
+OSNAME = $(shell uname)
 BUILD_DIR := $(DIST)/build
 SOURCE_DIR := ../sources
 SOURCE_FILES := $(wildcard $(SOURCE_DIR)/*.c)
 OBJECT_FILES := $(addprefix $(BUILD_DIR)/,$(notdir $(SOURCE_FILES:%.c=%.o)))
 HEADER_FILES := ../includes/.
+ifeq ($(OSNAME), Darwin)
 SIMPLE_LIB := lib$(PROGRAM_NAME).dylib
+else
+SIMPLE_LIB := lib$(PROGRAM_NAME).so
+endif
 ENTRY_FILE := ../simple.c
 LIB_FLAGS := -lm -ldl
 USR_LOCAL := /usr/local

--- a/test.sim
+++ b/test.sim
@@ -1,0 +1,3 @@
+call "simple/core/List.sim"
+
+


### PR DESCRIPTION
The current Makefile for Linux has some issues.

The `DESTDIR` variable is not defined and the `install` phony is trying to create directories that likely already exist. 

Apps like simple are ideally meant to be installed in `/usr/local/` not `/usr/`. Likewise, the make-compiled library shouldn't be put in `/usr/lib/x86_64-linux-gnu` unless you are cross-compiling and you are sure the compiled library will always be x86_64. 

This new makefile solves these problems and it can also compile the same on UNIX platforms. It was tested on both Macos and Linux. 

I also reduced a lot of the src/object files declaration boilerplate.

**PS:**
I've not had time to fix the Macos's build shell script. I think the Linux version can be refactored to work for Macos as well since they both now share the same Makefile.

I almost got simple working on my Android phone using this makefile but android filesystem hierarchy is a bit different and it may require some significant effort to get that working which is mainly figuring out how to load dynamic libraries.

The compiler flag verbosity you see in the makefile mainly comes from Linux or gcc doing a terrible job at handling some things automatically. 
